### PR TITLE
Fixed issue with use_canonical_name

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,8 +1,8 @@
 ---
 dependencies:
   - role: telusdigital.apt-repository
-    repository_key: "0xb9316a7bc7917b12"
-    repository_url: "deb http://ppa.launchpad.net/chris-lea/apache2/ubuntu {{ ansible_distribution_release }} main"
+    repository_key: "0x4f4ea0aae5267a6c"
+    repository_url: "deb http://ppa.launchpad.net/ondrej/apache2/ubuntu {{ ansible_distribution_release }} main"
 
 galaxy_info:
   author: "Ben Visser"

--- a/templates/etc/apache2/sites-available/site.conf
+++ b/templates/etc/apache2/sites-available/site.conf
@@ -9,6 +9,9 @@ DirectoryIndex index.php index.html
 {% if vhost.serveralias is defined %}
   ServerAlias {{ vhost.serveralias }}
 {% endif %}
+{% if vhost.use_canonical_name == "yes" %}
+UseCanonicalName On
+{% endif %}
   DocumentRoot {{ vhost.documentroot }}
 
 {% if vhost.serveradmin is defined %}

--- a/templates/etc/apache2/sites-available/site.conf
+++ b/templates/etc/apache2/sites-available/site.conf
@@ -9,8 +9,8 @@ DirectoryIndex index.php index.html
 {% if vhost.serveralias is defined %}
   ServerAlias {{ vhost.serveralias }}
 {% endif %}
-{% if vhost.use_canonical_name == "yes" %}
-UseCanonicalName On
+{% if vhost.use_canonical_name is defined %}
+  UseCanonicalName {{ use_canonical_name }}
 {% endif %}
   DocumentRoot {{ vhost.documentroot }}
 

--- a/tests/inventory
+++ b/tests/inventory
@@ -1,2 +1,1 @@
 localhost
-

--- a/tests/inventory
+++ b/tests/inventory
@@ -1,1 +1,2 @@
 localhost
+


### PR DESCRIPTION
I fixed an issue where is was failing due to use_canonical_name not being defined for use_vhost

Here is the result of my travis test:
[![Build Status](https://travis-ci.org/noqcks/ansible-apache.svg?branch=master)](https://travis-ci.org/noqcks/ansible-apache)